### PR TITLE
Add Etherscan GetContract tests

### DIFF
--- a/etherscan/etherscan.go
+++ b/etherscan/etherscan.go
@@ -127,9 +127,11 @@ func (e *Etherscan) GetBlockByNumber(i web3.BlockNumber, full bool) (*web3.Block
 }
 
 type ContractCode struct {
-	SourceCode      string
-	Runs            string
-	CompilerVersion string
+	SourceCode           string
+	ContractName         string
+	Runs                 string
+	CompilerVersion      string
+	ConstructorArguments string
 }
 
 func (e *Etherscan) GetContractCode(addr web3.Address) (*ContractCode, error) {

--- a/etherscan/etherscan_test.go
+++ b/etherscan/etherscan_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
 )
 
 func testEtherscanMainnet(t *testing.T) *Etherscan {
@@ -27,4 +28,14 @@ func TestGetBlockByNumber(t *testing.T) {
 	b, err := e.GetBlockByNumber(1, false)
 	assert.NoError(t, err)
 	assert.Equal(t, b.Number, uint64(1))
+}
+
+func TestContract(t *testing.T) {
+	e := testEtherscanMainnet(t)
+
+	// uniswap v2. router
+	code, err := e.GetContractCode(web3.HexToAddress("0x7a250d5630b4cf539739df2c5dacb4c659f2488d"))
+	assert.NoError(t, err)
+	assert.Equal(t, code.Runs, "999999")
+
 }


### PR DESCRIPTION
This PR adds a test for the GetContractCode Etherscan function.