### PR TITLE
Add copy functions for core types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 # 0.1.1 (Not released)
 
+- Add `Copy` function to major data types [[GH-169](https://github.com/umbracle/ethgo/issues/169)]
 - Parse `fixed bytes` type in event topic [[GH-168](https://github.com/umbracle/ethgo/issues/168)]
 - Introduce `NodeProvider` and update `Contract` and `abigen` format. [[GH-167](https://github.com/umbracle/ethgo/issues/167)]
 

--- a/structs.go
+++ b/structs.go
@@ -148,6 +148,20 @@ type Block struct {
 	Uncles             []Hash
 }
 
+func (b *Block) Copy() *Block {
+	bb := new(Block)
+	*bb = *b
+	if b.Difficulty != nil {
+		bb.Difficulty = new(big.Int).Set(b.Difficulty)
+	}
+	bb.ExtraData = append(bb.ExtraData[:0], b.ExtraData...)
+	bb.Transactions = make([]*Transaction, len(b.Transactions))
+	for indx, txn := range b.Transactions {
+		bb.Transactions[indx] = txn.Copy()
+	}
+	return bb
+}
+
 type TransactionType int
 
 const (
@@ -186,6 +200,31 @@ type Transaction struct {
 	// eip-1559 values
 	MaxPriorityFeePerGas *big.Int
 	MaxFeePerGas         *big.Int
+}
+
+func (t *Transaction) Copy() *Transaction {
+	tt := new(Transaction)
+	if t.To != nil {
+		to := Address(*t.To)
+		tt.To = &to
+	}
+	tt.Input = append(tt.Input[:0], t.Input...)
+	if t.Value != nil {
+		tt.Value = new(big.Int).Set(t.Value)
+	}
+	tt.V = append(tt.V[:0], t.V...)
+	tt.R = append(tt.R[:0], t.R...)
+	tt.S = append(tt.S[:0], t.S...)
+	if t.ChainID != nil {
+		tt.ChainID = new(big.Int).Set(t.ChainID)
+	}
+	if t.MaxPriorityFeePerGas != nil {
+		tt.MaxPriorityFeePerGas = new(big.Int).Set(t.MaxPriorityFeePerGas)
+	}
+	if t.MaxFeePerGas != nil {
+		tt.MaxFeePerGas = new(big.Int).Set(t.MaxFeePerGas)
+	}
+	return tt
 }
 
 type AccessEntry struct {
@@ -240,6 +279,17 @@ type Receipt struct {
 	Status            uint64
 }
 
+func (r *Receipt) Copy() *Receipt {
+	rr := new(Receipt)
+	*rr = *r
+	rr.LogsBloom = append(rr.LogsBloom[:0], r.LogsBloom...)
+	rr.Logs = make([]*Log, len(r.Logs))
+	for indx, log := range r.Logs {
+		rr.Logs[indx] = log.Copy()
+	}
+	return rr
+}
+
 type Log struct {
 	Removed          bool
 	LogIndex         uint64
@@ -250,6 +300,13 @@ type Log struct {
 	Address          Address
 	Topics           []Hash
 	Data             []byte
+}
+
+func (l *Log) Copy() *Log {
+	ll := new(Log)
+	*ll = *l
+	ll.Data = append(ll.Data[:0], l.Data...)
+	return ll
 }
 
 type BlockNumber int
@@ -288,12 +345,6 @@ func EncodeBlock(block ...BlockNumber) BlockNumber {
 
 type BlockNumberOrHash interface {
 	Location() string
-}
-
-func (b *Block) Copy() *Block {
-	bb := new(Block)
-	*bb = *b
-	return bb
 }
 
 func min(i, j int) int {

--- a/structs_test.go
+++ b/structs_test.go
@@ -1,6 +1,8 @@
 package ethgo
 
 import (
+	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,4 +43,50 @@ func TestAddress_HexToString(t *testing.T) {
 
 func TestHash_HexToString(t *testing.T) {
 	assert.Equal(t, HexToHash("1").String(), "0x0000000000000000000000000000000000000000000000000000000000000001")
+}
+
+func TestBlock_Copy(t *testing.T) {
+	b := &Block{
+		Difficulty:   big.NewInt(1),
+		Transactions: []*Transaction{},
+		ExtraData:    []byte{0x1, 0x2},
+	}
+	b1 := b.Copy()
+	if !reflect.DeepEqual(b, b1) {
+		t.Fatal("incorrect block copy")
+	}
+}
+
+func TestTransaction_Copy(t *testing.T) {
+	txn := &Transaction{
+		Input: []byte{0x1, 0x2},
+		V:     []byte{0x1, 0x2},
+		R:     []byte{0x1, 0x2},
+		S:     []byte{0x1, 0x2},
+	}
+	txn1 := txn.Copy()
+	if !reflect.DeepEqual(txn, txn1) {
+		t.Fatal("incorrect transaction")
+	}
+}
+
+func TestReceipt_Copy(t *testing.T) {
+	r := &Receipt{
+		LogsBloom: []byte{0x1, 0x2},
+		Logs:      []*Log{},
+	}
+	rr := r.Copy()
+	if !reflect.DeepEqual(r, rr) {
+		t.Fatal("incorrect receipt")
+	}
+}
+
+func TestLog_Copy(t *testing.T) {
+	l := &Log{
+		Data: []byte{0x1, 0x2},
+	}
+	ll := l.Copy()
+	if !reflect.DeepEqual(l, ll) {
+		t.Fatal("incorrect receipt")
+	}
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -26,9 +26,15 @@ func CompareBlocks(one, two []*ethgo.Block) bool {
 	}
 	// difficulty is hard to check, set the values to zero
 	for _, i := range one {
+		if i.Transactions == nil {
+			i.Transactions = []*ethgo.Transaction{}
+		}
 		i.Difficulty = big.NewInt(0)
 	}
 	for _, i := range two {
+		if i.Transactions == nil {
+			i.Transactions = []*ethgo.Transaction{}
+		}
 		i.Difficulty = big.NewInt(0)
 	}
 	return reflect.DeepEqual(one, two)


### PR DESCRIPTION
This PR includes a `Copy() <T>` function for each of the major types (`Block`, `Transaction`, `Receipt` and `Log`).