### PR TITLE
fix websocket transport

### DIFF
--- a/jsonrpc/transport/websocket.go
+++ b/jsonrpc/transport/websocket.go
@@ -183,8 +183,9 @@ func (s *stream) setHandler(id uint64, ack chan *ackMessage) {
 func (s *stream) Call(method string, out interface{}, params ...interface{}) error {
 	seq := s.incSeq()
 	request := codec.Request{
-		ID:     seq,
-		Method: method,
+		JsonRPC: "2.0",
+		ID:      seq,
+		Method:  method,
 	}
 	if len(params) > 0 {
 		data, err := json.Marshal(params)


### PR DESCRIPTION
This PR fixes the transport call of WebSocket.

The current version does not add the parameter JsonRPC. And because of that, the server returns an "invalid request" message, like the following

```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32600,
        "message": "Invalid request"
    },
    "id": 0
}
```

In order to fix that I've added the parameter on the codec request construction at the call method, similar to what is already practiced for the HTTP transport implementation.