### PR TITLE
[DoS] fix potential index out of range in txn unmarshalling

### DIFF
--- a/structs_marshal_rlp.go
+++ b/structs_marshal_rlp.go
@@ -84,6 +84,9 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) (*fastrlp.Value, erro
 func (t *Transaction) UnmarshalRLP(buf []byte) error {
 	t.Hash = BytesToHash(Keccak256(buf))
 
+	if len(buf) < 1 {
+		return fmt.Errorf("expecting 1 byte but 0 byte provided")
+	}
 	if buf[0] <= 0x7f {
 		// it includes a type byte
 		switch typ := buf[0]; typ {


### PR DESCRIPTION
This is a critical DoS issue because multiple blockchain projects are using this to parse txn gossipped from other nodes or provided by users. Without this fixed, attackers can easily crash blockchain nodes.