### PR TITLE
Add bound check to abi encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 # 0.1.2 (Unreleased)
 
+- Fix out-of-bounds reading of bytes during ABI decoding [[GH-205](https://github.com/umbracle/ethgo/issues/205)]
 - Update `fastrlp` to `59d5dd3` commit to fix a bug on bytes length check [[GH-204](https://github.com/umbracle/ethgo/issues/204)]
 - Update `btcd` library to new `v0.22.1`
 - Add option in `contract` to send transactions with EIP-1559 [[GH-198](https://github.com/umbracle/ethgo/issues/198)]

--- a/abi/decode.go
+++ b/abi/decode.go
@@ -172,6 +172,10 @@ func decodeTuple(t *Type, data []byte) (interface{}, []byte, error) {
 	orig := data
 	origLen := len(orig)
 	for indx, arg := range t.tuple {
+		if len(data) < 32 {
+			return nil, nil, fmt.Errorf("incorrect length")
+		}
+
 		entry := data
 		if arg.Elem.isDynamicType() {
 			offset, err := readOffset(data, origLen)
@@ -224,6 +228,10 @@ func decodeArraySlice(t *Type, data []byte, size int) (interface{}, []byte, erro
 	origLen := len(orig)
 	for indx := 0; indx < size; indx++ {
 		isDynamic := t.elem.isDynamicType()
+
+		if len(data) < 32 {
+			return nil, nil, fmt.Errorf("incorrect length")
+		}
 
 		entry := data
 		if isDynamic {

--- a/abi/decode_test.go
+++ b/abi/decode_test.go
@@ -1,0 +1,8 @@
+package abi
+
+import "testing"
+
+func TestDecode_BytesBound(t *testing.T) {
+	typ := MustNewType("tuple(string)")
+	decodeTuple(typ, nil) // it should not panic
+}


### PR DESCRIPTION
This PR fixes a possible out-of-bounds reading of the input bytes array during decoding.