### PR TITLE
Expect the correct JSON/RPC results from eth_getFilterChanges calls

### DIFF
--- a/jsonrpc/eth.go
+++ b/jsonrpc/eth.go
@@ -73,16 +73,11 @@ func (e *Eth) GetBlockByHash(hash ethgo.Hash, full bool) (*ethgo.Block, error) {
 
 // GetFilterChanges returns the filter changes for log filters
 func (e *Eth) GetFilterChanges(id string) ([]*ethgo.Log, error) {
-	var raw string
-	err := e.c.Call("eth_getFilterChanges", &raw, id)
-	if err != nil {
+	var logs []*ethgo.Log
+	if err := e.c.Call("eth_getFilterChanges", &logs, id); err != nil {
 		return nil, err
 	}
-	var res []*ethgo.Log
-	if err := json.Unmarshal([]byte(raw), &res); err != nil {
-		return nil, err
-	}
-	return res, nil
+	return logs, nil
 }
 
 // GetTransactionByHash returns a transaction by his hash
@@ -94,16 +89,11 @@ func (e *Eth) GetTransactionByHash(hash ethgo.Hash) (*ethgo.Transaction, error) 
 
 // GetFilterChangesBlock returns the filter changes for block filters
 func (e *Eth) GetFilterChangesBlock(id string) ([]ethgo.Hash, error) {
-	var raw string
-	err := e.c.Call("eth_getFilterChanges", &raw, id)
-	if err != nil {
+	var hashes []ethgo.Hash
+	if err := e.c.Call("eth_getFilterChanges", &hashes, id); err != nil {
 		return nil, err
 	}
-	var res []ethgo.Hash
-	if err := json.Unmarshal([]byte(raw), &res); err != nil {
-		return nil, err
-	}
-	return res, nil
+	return hashes, nil
 }
 
 // NewFilter creates a new log filter


### PR DESCRIPTION
See:
- Edge Issue https://github.com/0xPolygon/polygon-edge/issues/640
- Edge PR: https://github.com/0xPolygon/polygon-edge/pull/641

The `ethgo` code had a workaround in it, for an issue with the Polygon Edge JSON/RPC responses for `eth_getFilterChanges`. Specifically that they were returning a `string` rather than JSON Arrays in the `result`.

This PR updates `ethgo` to expect the standard outputs from these JSON/RPC functions, and hence depends on https://github.com/0xPolygon/polygon-edge/pull/641 to work with Polygon Edge.