### PR TITLE
Use custom tag for DecodeStruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.4 (Unreleased)
+
+- feat: `abi` DecodeStruct uses the `abi` tag instead of the default `mapstructure` [[GH-211](https://github.com/umbracle/ethgo/issues/211)]
+- feat: Implement `ens` reverse resolver [[GH-210](https://github.com/umbracle/ethgo/issues/210)]
+- fix: Jsonrpc eth_getLogs request cannot return string [[GH-209](https://github.com/umbracle/ethgo/issues/209)]
 
 # 0.1.3 (13 June, 2022)
 

--- a/abi/decode.go
+++ b/abi/decode.go
@@ -26,7 +26,17 @@ func DecodeStruct(t *Type, input []byte, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := mapstructure.Decode(val, out); err != nil {
+
+	dc := &mapstructure.DecoderConfig{
+		Result:           out,
+		WeaklyTypedInput: true,
+		TagName:          "abi",
+	}
+	ms, err := mapstructure.NewDecoder(dc)
+	if err != nil {
+		return err
+	}
+	if err = ms.Decode(val); err != nil {
 		return err
 	}
 	return nil

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -682,10 +682,10 @@ func testTypeWithContract(t *testing.T, server *testutil.TestServer, typ *Type) 
 }
 
 func TestEncodingStruct(t *testing.T) {
-	typ := MustNewType("tuple(address a, uint256 b)")
+	typ := MustNewType("tuple(address aa, uint256 b)")
 
 	type Obj struct {
-		A ethgo.Address
+		A ethgo.Address `abi:"aa"`
 		B *big.Int
 	}
 	obj := Obj{


### PR DESCRIPTION
This PR includes a custom struct tag for `abi.DecodeStruct`.