### PR TITLE
Fix `TestServer` deployment again

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -157,7 +157,9 @@ func NewTestServer(t *testing.T, addrs ...string) *TestServer {
 		addr = "http://127.0.0.1:8545"
 	}
 
-	server := &TestServer{}
+	server := &TestServer{
+		addr: addr,
+	}
 
 	server.client = &ethClient{addr}
 	if err := server.client.call("eth_accounts", &server.accounts); err != nil {
@@ -184,7 +186,7 @@ func (t *TestServer) WSAddr() string {
 
 // HTTPAddr returns the http endpoint
 func (t *TestServer) HTTPAddr() string {
-	return fmt.Sprintf("http://localhost:8545")
+	return fmt.Sprintf(t.addr)
 }
 
 // ProcessBlock processes a new block

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -4,9 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
 )
 
 func TestDeployServer(t *testing.T) {
 	srv := DeployTestServer(t, nil)
 	require.NotEmpty(t, srv.accounts)
+
+	clt := &ethClient{srv.HTTPAddr()}
+	account := []ethgo.Address{}
+
+	err := clt.call("eth_accounts", &account)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
In the previous PR to fix `TestServer` the address was not set.