### PR TITLE
Add internal type to abi type

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -404,10 +404,11 @@ func buildSignature(name string, typ *Type) string {
 
 // ArgumentStr encodes a type object
 type ArgumentStr struct {
-	Name       string
-	Type       string
-	Indexed    bool
-	Components []*ArgumentStr
+	Name         string
+	Type         string
+	Indexed      bool
+	Components   []*ArgumentStr
+	InternalType string
 }
 
 var keccakPool = sync.Pool{

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -1,11 +1,11 @@
 package abi
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAbi(t *testing.T) {
@@ -106,12 +106,33 @@ func TestAbi(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(abi, c.Output) {
-				fmt.Println(reflect.DeepEqual(abi.Methods["balanceOf"].Outputs, c.Output.Methods["balanceOf"].Outputs))
 				t.Fatal("bad")
 			}
-
 		})
 	}
+}
+
+func TestAbi_InternalType(t *testing.T) {
+	const abiStr = `[
+        {
+            "inputs": [
+                {
+                    "internalType": "custom_address",
+                    "name": "_to",
+                    "type": "address"
+                }
+			],
+			"outputs": [],
+			"name": "transfer",
+			"type": "function"
+		}
+	]`
+
+	abi, err := NewABI(abiStr)
+	require.NoError(t, err)
+
+	typ := abi.GetMethod("transfer").Inputs
+	require.Equal(t, typ.tuple[0].Elem.InternalType(), "custom_address")
 }
 
 func TestAbi_Polymorphism(t *testing.T) {

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -116,6 +116,21 @@ func TestAbi_InternalType(t *testing.T) {
 	const abiStr = `[
         {
             "inputs": [
+				{
+					"components": [
+						{
+							"internalType": "address",
+							"type": "address"
+						},
+						{
+							"internalType": "uint256[4]",
+							"type": "uint256[4]"
+						}
+					],
+					"internalType": "struct X",
+					"name": "newSet",
+					"type": "tuple[]"
+				},
                 {
                     "internalType": "custom_address",
                     "name": "_to",
@@ -132,7 +147,10 @@ func TestAbi_InternalType(t *testing.T) {
 	require.NoError(t, err)
 
 	typ := abi.GetMethod("transfer").Inputs
-	require.Equal(t, typ.tuple[0].Elem.InternalType(), "custom_address")
+	require.Equal(t, typ.tuple[0].Elem.InternalType(), "struct X")
+	require.Equal(t, typ.tuple[0].Elem.elem.tuple[0].Elem.InternalType(), "address")
+	require.Equal(t, typ.tuple[0].Elem.elem.tuple[1].Elem.InternalType(), "uint256[4]")
+	require.Equal(t, typ.tuple[1].Elem.InternalType(), "custom_address")
 }
 
 func TestAbi_Polymorphism(t *testing.T) {

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestType(t *testing.T) {
@@ -361,6 +362,30 @@ func TestType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTypeArgument_InternalFields(t *testing.T) {
+	arg := &ArgumentStr{
+		Type: "tuple",
+		Components: []*ArgumentStr{
+			{
+				Type: "tuple",
+				Components: []*ArgumentStr{
+					{
+						Type:         "int32",
+						InternalType: "c",
+					},
+				},
+				InternalType: "b",
+			},
+		},
+	}
+
+	res, err := NewTypeFromArgument(arg)
+	require.NoError(t, err)
+
+	require.Equal(t, res.tuple[0].Elem.itype, "b")
+	require.Equal(t, res.tuple[0].Elem.tuple[0].Elem.itype, "c")
 }
 
 func TestSize(t *testing.T) {

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -369,7 +369,7 @@ func TestTypeArgument_InternalFields(t *testing.T) {
 		Type: "tuple",
 		Components: []*ArgumentStr{
 			{
-				Type: "tuple",
+				Type: "tuple[]",
 				Components: []*ArgumentStr{
 					{
 						Type:         "int32",
@@ -385,7 +385,7 @@ func TestTypeArgument_InternalFields(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, res.tuple[0].Elem.itype, "b")
-	require.Equal(t, res.tuple[0].Elem.tuple[0].Elem.itype, "c")
+	require.Equal(t, res.tuple[0].Elem.elem.tuple[0].Elem.itype, "c")
 }
 
 func TestSize(t *testing.T) {


### PR DESCRIPTION
This PR adds the field `internalType` from the `abi` JSON file to the `abi.Type` object.