### PR TITLE
Add eth_call override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.1.4 (Unreleased)
 
+- feat: Add override to `eth_call` request [[GH-240](https://github.com/umbracle/ethgo/issues/240)]
 - fix: Recovery of typed transactions [[GH-238](https://github.com/umbracle/ethgo/issues/238)]
 - fix: Parse `nonce` and `mixHash` on `Block` [[GH-228](https://github.com/umbracle/ethgo/issues/228)]
 - feat: `abi` decodes function string in multilines [[GH-212](https://github.com/umbracle/ethgo/issues/212)]

--- a/jsonrpc/eth.go
+++ b/jsonrpc/eth.go
@@ -171,9 +171,14 @@ func (e *Eth) GasPrice() (uint64, error) {
 }
 
 // Call executes a new message call immediately without creating a transaction on the block chain.
-func (e *Eth) Call(msg *ethgo.CallMsg, block ethgo.BlockNumber) (string, error) {
+func (e *Eth) Call(msg *ethgo.CallMsg, block ethgo.BlockNumber, override ...*ethgo.StateOverride) (string, error) {
+	var cleanOverride *ethgo.StateOverride
+	if len(override) == 1 && override[0] != nil {
+		cleanOverride = override[0]
+	}
+
 	var out string
-	if err := e.c.Call("eth_call", &out, msg, block.String()); err != nil {
+	if err := e.c.Call("eth_call", &out, msg, block.String(), cleanOverride); err != nil {
 		return "", err
 	}
 	return out, nil

--- a/structs.go
+++ b/structs.go
@@ -392,3 +392,13 @@ func completeHex(str string, num int) []byte {
 	}
 	return []byte("0x" + str)
 }
+
+type OverrideAccount struct {
+	Nonce     *uint64
+	Code      *[]byte
+	Balance   *big.Int
+	State     *map[Hash]Hash
+	StateDiff *map[Hash]Hash
+}
+
+type StateOverride map[Address]OverrideAccount

--- a/structs_marshal.go
+++ b/structs_marshal.go
@@ -254,3 +254,41 @@ func (l *LogFilter) MarshalJSON() ([]byte, error) {
 	defaultArena.Put(a)
 	return res, nil
 }
+
+func (s StateOverride) MarshalJSON() ([]byte, error) {
+	a := defaultArena.Get()
+
+	o := a.NewObject()
+	for addr, obj := range s {
+		oo := a.NewObject()
+		if obj.Nonce != nil {
+			oo.Set("nonce", a.NewString(fmt.Sprintf("0x%x", *obj.Nonce)))
+		}
+		if obj.Balance != nil {
+			oo.Set("balance", a.NewString(fmt.Sprintf("0x%x", obj.Balance)))
+		}
+		if obj.Code != nil {
+			oo.Set("code", a.NewString("0x"+hex.EncodeToString(*obj.Code)))
+		}
+		if obj.State != nil {
+			ooo := a.NewObject()
+			for k, v := range *obj.State {
+				ooo.Set(k.String(), a.NewString(v.String()))
+			}
+			oo.Set("state", ooo)
+		}
+		if obj.StateDiff != nil {
+			ooo := a.NewObject()
+			for k, v := range *obj.StateDiff {
+				ooo.Set(k.String(), a.NewString(v.String()))
+			}
+			oo.Set("stateDiff", ooo)
+		}
+		o.Set(addr.String(), oo)
+	}
+
+	res := o.MarshalTo(nil)
+	defaultArena.Put(a)
+
+	return res, nil
+}

--- a/structs_marshal_test.go
+++ b/structs_marshal_test.go
@@ -2,9 +2,11 @@ package ethgo
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func generateHashPtr(input string) *Hash {
@@ -93,4 +95,29 @@ func TestLogFilter_MarshalJSON(t *testing.T) {
 			assert.Equal(t, defaultLogFilter, reverseOutput)
 		})
 	}
+}
+
+func TestMarshal_StateOverride(t *testing.T) {
+	nonce := uint64(1)
+	code := []byte{0x1}
+
+	o := StateOverride{
+		{0x0}: OverrideAccount{
+			Nonce:   &nonce,
+			Balance: big.NewInt(1),
+			Code:    &code,
+			State: &map[Hash]Hash{
+				{0x1}: {0x1},
+			},
+			StateDiff: &map[Hash]Hash{
+				{0x1}: {0x1},
+			},
+		},
+	}
+
+	res, err := o.MarshalJSON()
+	require.NoError(t, err)
+
+	expected := `{"0x0000000000000000000000000000000000000000":{"nonce":"0x1","balance":"0x1","code":"0x01","state":{"0x0100000000000000000000000000000000000000000000000000000000000000":"0x0100000000000000000000000000000000000000000000000000000000000000"},"stateDiff":{"0x0100000000000000000000000000000000000000000000000000000000000000":"0x0100000000000000000000000000000000000000000000000000000000000000"}}}`
+	require.Equal(t, expected, string(res))
 }


### PR DESCRIPTION
This PR expands the `eth_call` JSON-RPC call to add the override.