### PR TITLE
Fix tracker errors after a block reorganization

### DIFF
--- a/blocktracker/blocktracker.go
+++ b/blocktracker/blocktracker.go
@@ -112,7 +112,8 @@ func (t *BlockTracker) Init() (err error) {
 				break
 			}
 			block, err = t.provider.GetBlockByHash(block.ParentHash, false)
-			if err != nil {
+			// if block does not exist (for example reorg happened) GetBlockByHash will return nil, nil
+			if err != nil || block == nil {
 				return
 			}
 		}
@@ -231,6 +232,9 @@ func (t *BlockTracker) handleReconcileImpl(block *ethgo.Block) ([]*ethgo.Block, 
 
 		parent, err := t.provider.GetBlockByHash(block.ParentHash, false)
 		if err != nil {
+			return nil, -1, fmt.Errorf("parent with hash retrieving error: %w", err)
+		} else if parent == nil {
+			// if block does not exist (for example reorg happened) GetBlockByHash will return nil, nil
 			return nil, -1, fmt.Errorf("parent with hash %s not found", block.ParentHash)
 		}
 

--- a/blocktracker/blocktracker.go
+++ b/blocktracker/blocktracker.go
@@ -112,8 +112,12 @@ func (t *BlockTracker) Init() (err error) {
 				break
 			}
 			block, err = t.provider.GetBlockByHash(block.ParentHash, false)
-			// if block does not exist (for example reorg happened) GetBlockByHash will return nil, nil
-			if err != nil || block == nil {
+			if err != nil {
+				return
+			} else if block == nil {
+				// if block does not exist (for example reorg happened) GetBlockByHash will return nil, nil
+				err = fmt.Errorf("block with hash %s not found", block.ParentHash)
+
 				return
 			}
 		}


### PR DESCRIPTION
The problem is when reorganization occurs on chain, so the parent block does not exist any more. function `handleReconcileImpl()` should check if the obtained block is `nil` (`parent == nil`):
`parent, err := t.provider.GetBlockByHash(block.ParentHash, false)`

There are some additional places in `blocktracker.go` and _tracker.go_ which should be handled also. They are introduces in this PR as well.