### PR TITLE
Attempt to connect to both ipv4 and ipv6 addresses

### DIFF
--- a/jsonrpc/transport/http.go
+++ b/jsonrpc/transport/http.go
@@ -16,8 +16,10 @@ type HTTP struct {
 
 func newHTTP(addr string, headers map[string]string) *HTTP {
 	return &HTTP{
-		addr:    addr,
-		client:  &fasthttp.Client{},
+		addr: addr,
+		client: &fasthttp.Client{
+			DialDualStack: true,
+		},
 		headers: headers,
 	}
 }


### PR DESCRIPTION
IPv6 endpoint addresses are currently not working by default, this enables IPv6 based endpoints.