### PR TITLE
Fix hash calculation for dynamic fee and access list transactions

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -164,7 +164,7 @@ func (b *Block) Copy() *Block {
 	return bb
 }
 
-type TransactionType int
+type TransactionType uint8
 
 const (
 	TransactionLegacy TransactionType = 0

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -82,7 +82,7 @@ func signHash(tx *ethgo.Transaction, chainID uint64) []byte {
 
 	if tx.Type != ethgo.TransactionLegacy {
 		// either dynamic and access type
-		v.Set(a.NewBigInt(tx.ChainID))
+		v.Set(a.NewBigInt(new(big.Int).SetUint64(chainID)))
 	}
 
 	v.Set(a.NewUint(tx.Nonce))
@@ -105,7 +105,7 @@ func signHash(tx *ethgo.Transaction, chainID uint64) []byte {
 	v.Set(a.NewBigInt(tx.Value))
 	v.Set(a.NewCopyBytes(tx.Input))
 
-	if tx.Type != 0 {
+	if tx.Type != ethgo.TransactionLegacy {
 		// either dynamic and access type
 		accessList, err := tx.AccessList.MarshalRLPWith(a)
 		if err != nil {

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"encoding/binary"
 	"math/big"
 
 	"github.com/umbracle/ethgo"
@@ -125,11 +124,8 @@ func signHash(tx *ethgo.Transaction, chainID uint64) []byte {
 
 	// append the tx type byte
 	if tx.Type != ethgo.TransactionLegacy {
-		typeBytes := make([]byte, 4)
-		binary.BigEndian.PutUint32(typeBytes, uint32(tx.Type))
-		dst = append(typeBytes, dst...)
+		dst = append([]byte{byte(tx.Type)}, dst...)
 	}
-
 	return ethgo.Keccak256(dst)
 }
 

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -26,18 +26,18 @@ func TestSigner_SignAndRecover(t *testing.T) {
 		// of the transaction.
 		txn.Type = ethgo.TransactionType(txType)
 		if txn.Type == ethgo.TransactionDynamicFee {
-			maxFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "max fee per gas")
+			maxFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "maxFeePerGas")
 			txn.MaxFeePerGas = big.NewInt(maxFeePerGas)
-			maxPriorityFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "max priority fee per gas")
+			maxPriorityFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "maxPriorityFeePerGas")
 			txn.MaxPriorityFeePerGas = big.NewInt(maxPriorityFeePerGas)
 		} else {
-			gasPrice := rapid.Uint64Range(1, 1000000000).Draw(t, "gas price")
+			gasPrice := rapid.Uint64Range(1, 1000000000).Draw(t, "gasPrice")
 			txn.GasPrice = gasPrice
 		}
 
 		// signer is from a random chain
-		chainid := rapid.Uint64().Draw(t, "chainid")
-		signer := NewEIP155Signer(chainid)
+		chainId := rapid.Uint64().Draw(t, "chainId")
+		signer := NewEIP155Signer(chainId)
 
 		key, err := GenerateKey()
 		require.NoError(t, err)

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -12,8 +12,6 @@ import (
 
 func TestSigner_SignAndRecover(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		istyped := rapid.Bool().Draw(t, "istyped")
-
 		// fill in common types for a transaction
 		txn := &ethgo.Transaction{}
 
@@ -22,10 +20,19 @@ func TestSigner_SignAndRecover(t *testing.T) {
 			txn.To = &to
 		}
 
+		txType := rapid.IntRange(0, 2).Draw(t, "tx type")
+
 		// fill in specific fields depending on the type
 		// of the transaction.
-		if istyped {
-			txn.Type = ethgo.TransactionAccessList
+		txn.Type = ethgo.TransactionType(txType)
+		if txn.Type == ethgo.TransactionDynamicFee {
+			maxFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "max fee per gas")
+			txn.MaxFeePerGas = big.NewInt(maxFeePerGas)
+			maxPriorityFeePerGas := rapid.Int64Range(1, 1000000000).Draw(t, "max priority fee per gas")
+			txn.MaxPriorityFeePerGas = big.NewInt(maxPriorityFeePerGas)
+		} else {
+			gasPrice := rapid.Uint64Range(1, 1000000000).Draw(t, "gas price")
+			txn.GasPrice = gasPrice
 		}
 
 		// signer is from a random chain


### PR DESCRIPTION
This PR simplifies transaction hash calculation a bit and uses the chain id provided by the hash function parameter, instead the one from the transaction object, since it can be empty.

Also, property-based tests include testing of dynamic fee transactions as well.