### PR TITLE
Added options to TraceTransaction function

### DIFF
--- a/jsonrpc/debug.go
+++ b/jsonrpc/debug.go
@@ -6,9 +6,19 @@ type Debug struct {
 	c *Client
 }
 
-// Eth returns the reference to the eth namespace
+// Debug returns the reference to the debug namespace
 func (c *Client) Debug() *Debug {
 	return c.endpoints.d
+}
+
+type TraceTransactionOptions struct {
+	EnableMemory     bool
+	DisableStack     bool
+	DisableStorage   bool
+	EnableReturnData bool
+	Timeout          string
+	Tracer           string
+	TracerConfig     map[string]interface{} `json:"tracerConfig,omitempty"`
 }
 
 type TransactionTrace struct {
@@ -28,8 +38,44 @@ type StructLogs struct {
 	Storage map[string]string
 }
 
-func (d *Debug) TraceTransaction(hash ethgo.Hash) (*TransactionTrace, error) {
+func (d *Debug) TraceTransaction(hash ethgo.Hash, opts *TraceTransactionOptions) (*TransactionTrace, error) {
 	var res *TransactionTrace
-	err := d.c.Call("debug_traceTransaction", &res, hash)
+	err := d.c.Call("debug_traceTransaction", &res, hash, toTraceTransactionOpts(opts))
 	return res, err
+}
+
+func toTraceTransactionOpts(opts *TraceTransactionOptions) map[string]interface{} {
+	optsMap := make(map[string]interface{})
+
+	if opts != nil {
+		if opts.EnableMemory {
+			optsMap["enableMemory"] = true
+		}
+
+		if opts.DisableStack {
+			optsMap["disableStack"] = true
+		}
+
+		if opts.DisableStorage {
+			optsMap["disableStorage"] = true
+		}
+
+		if opts.EnableReturnData {
+			optsMap["enableReturnData"] = true
+		}
+
+		if opts.Timeout != "" {
+			optsMap["timeout"] = opts.Timeout
+		}
+
+		if opts.Tracer != "" {
+			optsMap["tracer"] = opts.Tracer
+
+			if len(opts.TracerConfig) > 0 {
+				optsMap["tracerConfig"] = opts.TracerConfig
+			}
+		}
+	}
+
+	return optsMap
 }

--- a/jsonrpc/debug.go
+++ b/jsonrpc/debug.go
@@ -18,7 +18,7 @@ type TraceTransactionOptions struct {
 	EnableReturnData bool
 	Timeout          string
 	Tracer           string
-	TracerConfig     map[string]interface{} `json:"tracerConfig,omitempty"`
+	TracerConfig     map[string]interface{}
 }
 
 type TransactionTrace struct {

--- a/jsonrpc/debug.go
+++ b/jsonrpc/debug.go
@@ -12,13 +12,13 @@ func (c *Client) Debug() *Debug {
 }
 
 type TraceTransactionOptions struct {
-	EnableMemory     bool
-	DisableStack     bool
-	DisableStorage   bool
-	EnableReturnData bool
-	Timeout          string
-	Tracer           string
-	TracerConfig     map[string]interface{}
+	EnableMemory     bool                   `json:"enableMemory"`
+	DisableStack     bool                   `json:"disableStack"`
+	DisableStorage   bool                   `json:"disableStorage"`
+	EnableReturnData bool                   `json:"enableReturnData"`
+	Timeout          string                 `json:"timeout,omitempty"`
+	Tracer           string                 `json:"tracer,omitempty"`
+	TracerConfig     map[string]interface{} `json:"tracerConfig,omitempty"`
 }
 
 type TransactionTrace struct {
@@ -38,44 +38,8 @@ type StructLogs struct {
 	Storage map[string]string
 }
 
-func (d *Debug) TraceTransaction(hash ethgo.Hash, opts *TraceTransactionOptions) (*TransactionTrace, error) {
+func (d *Debug) TraceTransaction(hash ethgo.Hash, opts TraceTransactionOptions) (*TransactionTrace, error) {
 	var res *TransactionTrace
-	err := d.c.Call("debug_traceTransaction", &res, hash, toTraceTransactionOpts(opts))
+	err := d.c.Call("debug_traceTransaction", &res, hash, opts)
 	return res, err
-}
-
-func toTraceTransactionOpts(opts *TraceTransactionOptions) map[string]interface{} {
-	optsMap := make(map[string]interface{})
-
-	if opts != nil {
-		if opts.EnableMemory {
-			optsMap["enableMemory"] = true
-		}
-
-		if opts.DisableStack {
-			optsMap["disableStack"] = true
-		}
-
-		if opts.DisableStorage {
-			optsMap["disableStorage"] = true
-		}
-
-		if opts.EnableReturnData {
-			optsMap["enableReturnData"] = true
-		}
-
-		if opts.Timeout != "" {
-			optsMap["timeout"] = opts.Timeout
-		}
-
-		if opts.Tracer != "" {
-			optsMap["tracer"] = opts.Tracer
-
-			if len(opts.TracerConfig) > 0 {
-				optsMap["tracerConfig"] = opts.TracerConfig
-			}
-		}
-	}
-
-	return optsMap
 }

--- a/jsonrpc/debug_test.go
+++ b/jsonrpc/debug_test.go
@@ -22,8 +22,49 @@ func TestDebug_TraceTransaction(t *testing.T) {
 	r, err := s.TxnTo(addr, "setA2")
 	require.NoError(t, err)
 
-	trace, err := c.Debug().TraceTransaction(r.TransactionHash)
+	trace, err := c.Debug().TraceTransaction(r.TransactionHash, nil)
 	assert.NoError(t, err)
 	assert.Greater(t, trace.Gas, uint64(20000))
 	assert.NotEmpty(t, trace.StructLogs)
+}
+
+func Test_toTraceTransactionOpts(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *TraceTransactionOptions
+		want map[string]interface{}
+	}{
+		{
+			name: "all fields are provided",
+			opts: &TraceTransactionOptions{
+				EnableMemory:     true,
+				DisableStack:     true,
+				DisableStorage:   true,
+				EnableReturnData: true,
+				Timeout:          "1s",
+				Tracer:           "callTracer",
+				TracerConfig: map[string]interface{}{
+					"onlyTopCall": true,
+					"withLog":     true,
+				},
+			},
+			want: map[string]interface{}{
+				"disableStack":     true,
+				"disableStorage":   true,
+				"enableMemory":     true,
+				"enableReturnData": true,
+				"timeout":          "1s",
+				"tracer":           "callTracer",
+				"tracerConfig": map[string]interface{}{
+					"onlyTopCall": true,
+					"withLog":     true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, toTraceTransactionOpts(tt.opts), "toTraceTransactionOpts(%v)", tt.opts)
+		})
+	}
 }

--- a/jsonrpc/debug_test.go
+++ b/jsonrpc/debug_test.go
@@ -22,54 +22,8 @@ func TestDebug_TraceTransaction(t *testing.T) {
 	r, err := s.TxnTo(addr, "setA2")
 	require.NoError(t, err)
 
-	trace, err := c.Debug().TraceTransaction(r.TransactionHash, nil)
+	trace, err := c.Debug().TraceTransaction(r.TransactionHash, TraceTransactionOptions{})
 	assert.NoError(t, err)
 	assert.Greater(t, trace.Gas, uint64(20000))
 	assert.NotEmpty(t, trace.StructLogs)
-}
-
-func Test_toTraceTransactionOpts(t *testing.T) {
-	tests := []struct {
-		name string
-		opts *TraceTransactionOptions
-		want map[string]interface{}
-	}{
-		{
-			name: "nil options provided",
-			opts: nil,
-			want: map[string]interface{}{},
-		},
-		{
-			name: "all fields are provided",
-			opts: &TraceTransactionOptions{
-				EnableMemory:     true,
-				DisableStack:     true,
-				DisableStorage:   true,
-				EnableReturnData: true,
-				Timeout:          "1s",
-				Tracer:           "callTracer",
-				TracerConfig: map[string]interface{}{
-					"onlyTopCall": true,
-					"withLog":     true,
-				},
-			},
-			want: map[string]interface{}{
-				"disableStack":     true,
-				"disableStorage":   true,
-				"enableMemory":     true,
-				"enableReturnData": true,
-				"timeout":          "1s",
-				"tracer":           "callTracer",
-				"tracerConfig": map[string]interface{}{
-					"onlyTopCall": true,
-					"withLog":     true,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, toTraceTransactionOpts(tt.opts), "toTraceTransactionOpts(%v)", tt.opts)
-		})
-	}
 }

--- a/jsonrpc/debug_test.go
+++ b/jsonrpc/debug_test.go
@@ -35,6 +35,11 @@ func Test_toTraceTransactionOpts(t *testing.T) {
 		want map[string]interface{}
 	}{
 		{
+			name: "nil options provided",
+			opts: nil,
+			want: map[string]interface{}{},
+		},
+		{
 			name: "all fields are provided",
 			opts: &TraceTransactionOptions{
 				EnableMemory:     true,


### PR DESCRIPTION
According to the spec, `debug_traceTransaction` API endpoint accepts options which are not supported by ethgo now: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug_traceTransaction

This PR introduces options for the function that executes the given endpoint. 