### PR TITLE
Fix #258 Etherscan created with corresponding apiKey

### DIFF
--- a/etherscan/etherscan.go
+++ b/etherscan/etherscan.go
@@ -42,7 +42,7 @@ func NewEtherscanFromNetwork(n ethgo.Network, apiKey string) (*Etherscan, error)
 
 // NewEtherscan creates a new Etherscan service from a url
 func NewEtherscan(url, apiKey string) *Etherscan {
-	return &Etherscan{url: url}
+	return &Etherscan{url: url, apiKey: apiKey}
 }
 
 type proxyResponse struct {

--- a/etherscan/etherscan_test.go
+++ b/etherscan/etherscan_test.go
@@ -16,6 +16,14 @@ func testEtherscanMainnet(t *testing.T) *Etherscan {
 	return &Etherscan{url: "https://api.etherscan.io", apiKey: apiKey}
 }
 
+func TestNewEtherscan(t *testing.T) {
+	wantUrl := "http://test.url/"
+	wantApiKey := "abc123"
+	e := NewEtherscan(wantUrl, wantApiKey)
+	assert.Equal(t, wantUrl, e.url)
+	assert.Equal(t, wantApiKey, e.apiKey)
+}
+
 func TestBlockByNumber(t *testing.T) {
 	e := testEtherscanMainnet(t)
 	n, err := e.BlockNumber()


### PR DESCRIPTION
Fix #258. You forgot to add apiKey in NewEtherscan. Also added a test to check it automatically for future modifications.