### PR TITLE
fix "Code: -32600, Message: Invalid request" when using with hardhat

### DIFF
--- a/jsonrpc/transport/http.go
+++ b/jsonrpc/transport/http.go
@@ -43,6 +43,8 @@ func (h *HTTP) Call(method string, out interface{}, params ...interface{}) error
 			return err
 		}
 		request.Params = data
+	} else {
+		request.Params = []byte{'[', ']'}
 	}
 	raw, err := json.Marshal(request)
 	if err != nil {


### PR DESCRIPTION
params is wrong:

```
{"jsonrpc":"2.0","id":0,"method":"eth_gasPrice","params":null}
```

With `[]` instead of `null` it does not happen.  

It happened with

```sh
npx hardhat node
```

It didn't happen when using 

``` sh
docker run --name geth-test -d -p 8545:8545 -p 8546:8546 ethereum/client-go:v1.10.15 --dev --datadir /eth1data --ipcpath /eth1data/geth.ipc --http --http.addr 0.0.0.0 --http.api eth,net,web3,debug --ws --ws.addr 0.0.0.0 --verbosity 4

```